### PR TITLE
Manual socket config for 4MB heap support

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -243,7 +243,23 @@ public:
 class NtpOverlay : public tsl::Overlay {
 public:
     virtual void initServices() override {
-        ASSERT_FATAL(socketInitializeDefault());
+        constexpr SocketInitConfig socketInitConfig = {
+            // TCP buffers
+            .tcp_tx_buf_size     = 16 * 1024,   // 16 KB default
+            .tcp_rx_buf_size     = 16 * 1024*2,   // 16 KB default
+            .tcp_tx_buf_max_size = 64 * 1024,   // 64 KB default max
+            .tcp_rx_buf_max_size = 64 * 1024*2,   // 64 KB default max
+            
+            // UDP buffers
+            .udp_tx_buf_size     = 512,         // 512 B default
+            .udp_rx_buf_size     = 512,         // 512 B default
+        
+            // Socket buffer efficiency
+            .sb_efficiency       = 1,           // 0 = default, balanced memory vs CPU
+                                                // 1 = prioritize memory efficiency (smaller internal allocations)
+            .bsd_service_type    = BsdServiceType_Auto // Auto-select service
+        };
+        ASSERT_FATAL(socketInitialize(&socketInitConfig));
         ASSERT_FATAL(nifmInitialize(NifmServiceType_User));
         ASSERT_FATAL(timeInitialize());
         ASSERT_FATAL(smInitialize()); // Needed


### PR DESCRIPTION
Hey nedex,

I thought that this fix might be of interest. In the latest revision of my nx-ovlloader fork, we now have the option to manually configure the heap size on the fly, and on HOS 21 it is set to 4MB by default.  However since `socketInitializeDefault` uses `sb_efficiency=0` instead of `sb_efficiency=1` (which prioritizes memory efficiency) it ends up causing a crash on 4MB. After setting it to `1`, we are able to also increase `tcp_rx_buf_size` and `tcp_rx_buf_max_size` in the process without having any issues.

Just wanted to provide a simple solution for 4MB support.